### PR TITLE
cmd exp: Fix parameter name

### DIFF
--- a/commands/aow/exp.js
+++ b/commands/aow/exp.js
@@ -69,7 +69,7 @@ export async function execute(context) {
     }
   }
 
-  const currPoints = Math.floor(options.getInteger('current'));
+  const currPoints = Math.floor(options.getInteger('exp-points'));
 
   const maxLevel = EXP_POINTS.length;
   const maxPoints = EXP_POINTS[maxLevel-1];

--- a/src/l10n.js
+++ b/src/l10n.js
@@ -130,7 +130,7 @@ export class L10N {
     /** string template   */
     let template;
 
-    if (this.data.get(locale).has(resourceKey)) {
+    if (this.data.get(locale)?.has(resourceKey)) {
       template = this.data.get(locale).get(resourceKey);
     } else {
       locale = this.defaultLocale;


### PR DESCRIPTION
The correct parameters defined are exp-points and level.

Signed-off-by: Ondrej Pik <ondrej@amarulasolutions.com>